### PR TITLE
Fix missing client directive

### DIFF
--- a/src/app/hem.tsx
+++ b/src/app/hem.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { NextPage } from "next";
 import Image from "next/image";
 import styles from "./hem.module.css";


### PR DESCRIPTION
## Summary
- mark `Hem` component as a client component so that `@splinetool/react-spline` works properly

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d9f4462dc832cb80b382308820ffb