### PR TITLE
Add basic header and hero page

### DIFF
--- a/src/app/components/Header.module.css
+++ b/src/app/components/Header.module.css
@@ -1,0 +1,21 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  gap: 1rem;
+  background-color: var(--color-white);
+}
+
+.nav {
+  display: flex;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  background-color: var(--color-gray-100);
+}
+
+.nav a {
+  margin: 0 0.5rem;
+  text-decoration: none;
+  color: inherit;
+}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import Link from "next/link";
+import styles from "./Header.module.css";
+
+export default function Header() {
+  return (
+    <header className={styles.header}>
+      <div>MEMORA</div>
+      <nav className={styles.nav}>
+        <Link href="/">Hem</Link>
+        <Link href="/om-oss">Om oss</Link>
+        <Link href="/kontakt">Kontakt</Link>
+        <Link href="/priser">Priser</Link>
+        <Link href="/funktioner">Funktioner</Link>
+      </nav>
+    </header>
+  );
+}

--- a/src/app/hem/page.tsx
+++ b/src/app/hem/page.tsx
@@ -1,0 +1,15 @@
+export default function HemPage() {
+  return (
+    <section>
+      <h1>All kunskap, direkt i chatten</h1>
+      <p>
+        Anslut dina dokument och få svar med RAG-drivna AI-chatbotar –
+        smartare, snabbare och säkrare.
+      </p>
+      <div>
+        <button>Boka demo</button>
+        <button>Se funktioner</button>
+      </div>
+    </section>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import "./global.css";
+import Header from "./components/Header";
 
 export const metadata = {
   title: `Memora`,
@@ -11,7 +12,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <Header />
+        <main>{children}</main>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- show a small header on every page
- create Header component with nav links
- style header and nav links
- add a simple hero section for `/hem`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685dcbec774c832cb1b9ba565d7dc1f0